### PR TITLE
Bump commons-beanutils from 1.8.0 to 1.9.2 in /springboot-elasticsearch

### DIFF
--- a/springboot-elasticsearch/pom.xml
+++ b/springboot-elasticsearch/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.8.0</version>
+            <version>1.9.2</version>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>


### PR DESCRIPTION
Bumps commons-beanutils from 1.8.0 to 1.9.2.

Signed-off-by: dependabot[bot] <support@github.com>